### PR TITLE
fix: add workflow_dispatch to release.yml as a manual-trigger fallback

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -11,6 +11,7 @@ name: Release
 on:
   push:
     branches: [dev]
+  workflow_dispatch: {}
 
 permissions:
   contents: write


### PR DESCRIPTION
Diagnostic addition while debugging why release.yml never registered — turned out the real cause was the repo default branch being master instead of dev.