### PR TITLE
release.yml: add a schedule fallback (push events never fire from auto-merge)

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -10,11 +10,24 @@
 # lands on dev between workflow runs (e.g. a PR merge immediately followed
 # by an auto-merged Renovate PR) — v3.0.0 was silently skipped this way the
 # first time this workflow ran against a real multi-push burst.
+#
+# The `push` trigger alone turned out not to be enough either: GitHub Actions
+# never fires downstream push-triggered workflows for a push made by the
+# default GITHUB_TOKEN (documented, intentional, prevents recursive workflow
+# runs) — and every merge into `dev` now happens via auto-merge.yml using
+# that same token. So `push` almost never actually fires in practice here;
+# the `schedule` trigger below is the real mechanism that keeps this
+# self-healing, with `push`/`workflow_dispatch` as instant paths for the
+# cases that do trigger normally (a human's own commit/merge, or a manual
+# run). The tag-existence check above makes re-running this on a timer
+# completely safe — it's a no-op whenever nothing's actually unreleased.
 name: Release
 
 on:
   push:
     branches: [dev]
+  schedule:
+    - cron: '*/15 * * * *'
   workflow_dispatch: {}
 
 permissions:


### PR DESCRIPTION
Root cause of v3.0.0 never getting tagged after PR #66/#69: GitHub Actions never fires downstream `push`-triggered workflows for a push authored by the repository's own `GITHUB_TOKEN` (documented behavior, prevents recursive runs) -- and every merge into `dev` now happens via auto-merge.yml using that token. Confirmed via the Actions API: zero `event=push` runs of either ci.yml or release.yml since auto-merge started actually merging PRs; everything is `pull_request` or `workflow_dispatch`.

Adds a `schedule: '*/15 * * * *'` trigger alongside the existing ones. Safe to run unconditionally thanks to the tag-existence check from the prior fix (PR #69) -- a no-op whenever nothing is actually unreleased. `push`/`workflow_dispatch` remain as fast paths for the cases that do fire normally.

Local gate passes; workflow-only change.