### PR TITLE
Fix screenshot.jpg.license: drop GodoFredo credit on the new capture

### DIFF
--- a/screenshot.jpg.license
+++ b/screenshot.jpg.license
@@ -1,4 +1,3 @@
-SPDX-FileCopyrightText: 2017-2025 GodoFredo <hello@godofredo.ninja>
 SPDX-FileCopyrightText: 2026 Pavel Dimov <hello@dimov.xyz>
 
 SPDX-License-Identifier: GPL-3.0-or-later


### PR DESCRIPTION
screenshot.jpg.license carried a dual GodoFredo+Pavel Dimov copyright over mechanically from the old (2018) screenshot's header, but the file was fully replaced this branch with a fresh Playwright capture of the live site -- a different image with zero content in common with the original. Copyright should follow actual authored content, not the file path, so this drops the GodoFredo line. Caught by the user reviewing the diff after merge; audited every other dual-copyright file in the repo for the same mistake and confirmed this is the only one (everything else is a genuine edit of GodoFredo's original content, not a wholesale replacement).