### PR TITLE
Fix routes.yaml: page.godo-personal -> page.home-personal

### DIFF
--- a/routes.yaml
+++ b/routes.yaml
@@ -16,7 +16,7 @@ routes:
 
   /personal/:
     template: home-personal
-    data: page.godo-personal
+    data: page.home-personal
 
   /podcast/rss/:
     template: podcast/rss


### PR DESCRIPTION
Caught by the user reviewing routes.yaml: the /personal/ route still bound `data: page.godo-personal` even though its template was already renamed to `home-personal`. Confirmed the live site's own routes.yaml already uses `page.home-personal` -- this demo copy was just never brought in line. `page.porftfolio` (a pre-existing 2020 typo, unrelated to old-owner branding) is left untouched.